### PR TITLE
Update dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "co-wrap-all": "^1.0.0",
     "humps": "^2.0.1",
     "is-type-of": "^1.2.0",
-    "json-bigint": "^0.2.3",
+    "json-bigint": "^1.0.0",
     "long": "^4.0.0",
     "merge-descriptors": "^1.0.1",
     "protobufjs": "^6.8.8",
@@ -27,8 +27,8 @@
     "zetrix-encryption-nodejs": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "mocha": "^5.2.0"
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Prototype pollution in json-bigint leading to uncontrolled resource consumption. 
- [CVE Report](https://nvd.nist.gov/vuln/detail/CVE-2020-8237)

2. chai & mocha testing modules update to most recent versions.